### PR TITLE
Fixed NullPointerExceptions on Windows

### DIFF
--- a/src/com/stericson/RootShell/containers/RootClass.java
+++ b/src/com/stericson/RootShell/containers/RootClass.java
@@ -150,7 +150,7 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */ {
                 } catch (InterruptedException e) {
                 }
 
-                File rawFolder = new File("res/raw");
+                File rawFolder = new File("res" + File.separator + "raw");
                 if (!rawFolder.exists()) {
                     rawFolder.mkdirs();
                 }
@@ -159,14 +159,14 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */ {
                 if (onWindows) {
                     cmd = new String[]{
                             "cmd", "/C",
-                            "dx --dex --output=res/raw/anbuild.dex "
+                            "dx --dex --output=res" + File.separator + "raw" + File.separator + "anbuild.dex "
                                     + builtPath + File.separator + "anbuild.jar"
                     };
                 } else {
                     cmd = new String[]{
                             getPathToDx(),
                             "--dex",
-                            "--output=res/raw/anbuild.dex",
+                            "--output=res" + File.separator + "raw" + File.separator + "anbuild.dex",
                             builtPath + File.separator + "anbuild.jar"
                     };
                 }
@@ -177,11 +177,11 @@ public class RootClass /* #ANNOTATIONS extends AbstractProcessor */ {
                 } catch (InterruptedException e) {
                 }
             }
-            System.out.println("All done. ::: anbuild.dex should now be in your project's res/raw/ folder :::");
+            System.out.println("All done. ::: anbuild.dex should now be in your project's res" + File.separator + "raw" + File.separator + " folder :::");
         }
 
         protected void lookup(File path, List<File> fileList) {
-            String desourcedPath = path.toString().replace("src/", "");
+            String desourcedPath = path.toString().replace("src" + File.separator, "");
             File[] files = path.listFiles();
             for (File file : files) {
                 if (file.isDirectory()) {


### PR DESCRIPTION
Windows is DOS based and uses different (from unix) directory separators. This causes NullPointerExceptions in RootClass.

Partial copy of this pull: Stericson/RootTools#30
